### PR TITLE
Bump version to include liblsl with locale fix

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pylsl" %}
-{% set version = "1.13.0.b3" %}
+{% set version = "1.13.0.b6" %}
 
 package:
   name: "{{ name|lower }}"

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.13.1',
+    version='1.13.2',
 
     description='Python interface to the Lab Streaming Layer',
     long_description=long_description,


### PR DESCRIPTION
pylsl doesn't include the locale fix (https://github.com/sccn/liblsl/issues/24), so we need to publish a new version.