### PR TITLE
Rework ReceiveAndPlot

### DIFF
--- a/pylsl/examples/ReceiveAndPlot.py
+++ b/pylsl/examples/ReceiveAndPlot.py
@@ -11,8 +11,6 @@ pull_interval = 500  # ms between each pull operation
 
 
 class Inlet:
-    __slots__ = ['channel_count', 'inlet', 'name']
-    
     def __init__(self, info: pylsl.StreamInfo):
         self.inlet = pylsl.StreamInlet(info, max_buflen=plot_duration,
                                        processing_flags=pylsl.proc_clocksync | pylsl.proc_dejitter)
@@ -25,7 +23,6 @@ class Inlet:
 
 class DataInlet(Inlet):
     dtypes = [[], np.float32, np.float64, None, np.int32, np.int16, np.int8, np.int64]
-    __slots__ = ['buffer', 'curves']
 
     def __init__(self, info: pylsl.StreamInfo, plt: pg.PlotItem):
         super().__init__(info)

--- a/pylsl/examples/ReceiveAndPlot.py
+++ b/pylsl/examples/ReceiveAndPlot.py
@@ -14,7 +14,8 @@ class Inlet:
     __slots__ = ['channel_count', 'inlet', 'name']
     
     def __init__(self, info: pylsl.StreamInfo):
-        self.inlet = pylsl.StreamInlet(info, max_buflen=plot_duration)
+        self.inlet = pylsl.StreamInlet(info, max_buflen=plot_duration,
+                                       processing_flags=pylsl.proc_clocksync | pylsl.proc_dejitter)
         self.name = info.name()
         self.channel_count = info.channel_count()
 

--- a/pylsl/examples/ReceiveAndPlot.py
+++ b/pylsl/examples/ReceiveAndPlot.py
@@ -1,3 +1,14 @@
+#!/usr/bin/env python
+"""
+ReceiveAndPlot example for LSL
+
+This example shows data from all found outlets in realtime.
+It illustrates the following use cases:
+- efficiently pulling data, re-using buffers
+- automatically discarding older samples
+- online postprocessing
+"""
+
 import numpy as np
 import math
 import pylsl
@@ -5,38 +16,60 @@ import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtGui
 from typing import List
 
-plot_duration = 5
-update_interval = 60
+# Basic parameters for the plotting window
+plot_duration = 5  # how many seconds of data to show
+update_interval = 60  # ms between screen updates
 pull_interval = 500  # ms between each pull operation
 
 
 class Inlet:
+    """Base class to represent a plottable inlet"""
     def __init__(self, info: pylsl.StreamInfo):
+        # create an inlet and connect it to the outlet we found earlier.
+        # max_buflen is set so data older the plot_duration is discarded
+        # automatically and we only pull data new enough to show it
+
+        # Also, perform online clock synchronization so all streams are in the
+        # same time domain as the local lsl_clock()
+        # (see https://labstreaminglayer.readthedocs.io/projects/liblsl/ref/enums.html#_CPPv414proc_clocksync)
+        # and dejitter timestamps
         self.inlet = pylsl.StreamInlet(info, max_buflen=plot_duration,
                                        processing_flags=pylsl.proc_clocksync | pylsl.proc_dejitter)
+        # store the name and channel count
         self.name = info.name()
         self.channel_count = info.channel_count()
 
-    def pull_and_plot(self, plot_time, plt):
+    def pull_and_plot(self, plot_time: float, plt: pg.PlotItem):
+        """Pull data from the inlet and add it to the plot.
+        :param plot_time: lowest timestamp that's still visible in the plot
+        :param plt: the plot the data should be shown on
+        """
+        # We don't know what to do with a generic inlet, so we skip it.
         pass
 
 
 class DataInlet(Inlet):
+    """A DataInlet represents an inlet with continuous, multi-channel data that
+    should be plotted as multiple lines."""
     dtypes = [[], np.float32, np.float64, None, np.int32, np.int16, np.int8, np.int64]
 
     def __init__(self, info: pylsl.StreamInfo, plt: pg.PlotItem):
         super().__init__(info)
-        bufsize = (2*math.ceil(info.nominal_srate()*plot_duration), info.channel_count())
+        # calculate the size for our buffer, i.e. two times the displayed data
+        bufsize = (2 * math.ceil(info.nominal_srate() * plot_duration), info.channel_count())
         self.buffer = np.empty(bufsize, dtype=self.dtypes[info.channel_format()])
         empty = np.array([])
+        # create one curve object for each channel/line that will handle displaying the data
         self.curves = [pg.PlotCurveItem(x=empty, y=empty, autoDownsample=True) for _ in range(self.channel_count)]
         for curve in self.curves:
             plt.addItem(curve)
 
     def pull_and_plot(self, plot_time, plt):
+        # pull the data
         _, ts = self.inlet.pull_chunk(timeout=0.0,
                                       max_samples=self.buffer.shape[0],
                                       dest_obj=self.buffer)
+        # ts will be empty if no samples were pulled, a list of timestamps otherwise
         if ts:
             ts = np.asarray(ts)
             y = self.buffer[0:ts.size, :]
@@ -44,16 +77,28 @@ class DataInlet(Inlet):
             old_offset = 0
             new_offset = 0
             for ch_ix in range(self.channel_count):
+                # we don't pull an entire screen's worth of data, so we have to
+                # trim the old data and append the new data to it
                 old_x, old_y = self.curves[ch_ix].getData()
+                # the timestamps are identical for all channels, so we need to do
+                # this calculation only once
                 if ch_ix == 0:
+                    # find the index of the first sample that's still visible,
+                    # i.e. newer than the left border of the plot
                     old_offset = old_x.searchsorted(plot_time)
+                    # same for the new data, in case we pulled more data than
+                    # can be shown at once
                     new_offset = ts.searchsorted(plot_time)
+                    # append new timestamps to the trimmed old timestamps
                     this_x = np.hstack((old_x[old_offset:], ts[new_offset:]))
+                # append new data to the trimmed old data
                 this_y = np.hstack((old_y[old_offset:], y[new_offset:, ch_ix] - ch_ix))
+                # replace the old data
                 self.curves[ch_ix].setData(this_x, this_y)
 
 
 class MarkerInlet(Inlet):
+    """A MarkerInlet shows events that happen sporadically as vertical lines"""
     def __init__(self, info: pylsl.StreamInfo):
         super().__init__(info)
 
@@ -66,7 +111,7 @@ class MarkerInlet(Inlet):
 
 
 def main():
-    # first resolve an EEG stream on the lab network
+    # firstly resolve all streams that could be shown
     inlets: List[Inlet] = []
     print("looking for streams")
     streams = pylsl.resolve_streams()
@@ -76,6 +121,8 @@ def main():
     plt = pw.getPlotItem()
     plt.enableAutoRange(x=False, y=True)
 
+    # iterate over found streams, creating specialized inlet objects that will
+    # handle plotting the data
     for info in streams:
         if info.type() == 'Markers':
             if info.nominal_srate() != pylsl.IRREGULAR_RATE \
@@ -91,21 +138,28 @@ def main():
             print('Don\'t know what to do with stream ' + info.name())
 
     def scroll():
+        """Move the view so the data appears to scroll"""
+        # We show data only up to a timepoint shortly before the current time
+        # so new data doesn't suddenly appear in the middle of the plot
         fudge_factor = pull_interval * .002
         plot_time = pylsl.local_clock()
         pw.setXRange(plot_time - plot_duration + fudge_factor, plot_time - fudge_factor)
 
     def update():
         # Read data from the inlet. Use a timeout of 0.0 so we don't block GUI interaction.
-        current_inlet = 0
-        mintime = pylsl.local_clock()
+        mintime = pylsl.local_clock() - plot_duration
+        # call pull_and_plot for each inlet.
+        # Special handling of inlet types (markers, continuous data) is done in
+        # the different inlet classes.
         for inlet in inlets:
-            inlet.pull_and_plot(mintime - plot_duration, plt)
+            inlet.pull_and_plot(mintime, plt)
 
+    # create a timer that will move the view every update_interval ms
     update_timer = QtCore.QTimer()
     update_timer.timeout.connect(scroll)
     update_timer.start(update_interval)
 
+    # create a timer that will pull and add new data occasionally
     pull_timer = QtCore.QTimer()
     pull_timer.timeout.connect(update)
     pull_timer.start(pull_interval)

--- a/pylsl/examples/ReceiveAndPlot.py
+++ b/pylsl/examples/ReceiveAndPlot.py
@@ -1,68 +1,123 @@
 import numpy as np
-from pylsl import StreamInlet, resolve_stream, local_clock
+import math
+import pylsl
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtGui
+from typing import List
+
+plot_duration = 5
+update_interval = 60
+pull_interval = 500  # ms between each pull operation
 
 
-plot_duration = 2.0
+class Inlet:
+    __slots__ = ['channel_count', 'inlet', 'name']
+    
+    def __init__(self, info: pylsl.StreamInfo):
+        self.inlet = pylsl.StreamInlet(info, max_buflen=plot_duration)
+        self.name = info.name()
+        self.channel_count = info.channel_count()
+
+    def pull_and_plot(self, plot_time, plt):
+        pass
 
 
-# first resolve an EEG stream on the lab network
-print("looking for an EEG stream...")
-streams = resolve_stream('type', 'EEG')
+class DataInlet(Inlet):
+    dtypes = [[], np.float32, np.float64, None, np.int32, np.int16, np.int8, np.int64]
+    __slots__ = ['buffer', 'curves']
 
-# create a new inlet to read from the stream
-inlet = StreamInlet(streams[0])
-markers = StreamInlet(resolve_stream('type', 'Markers')[0])
+    def __init__(self, info: pylsl.StreamInfo, plt: pg.PlotItem):
+        super().__init__(info)
+        bufsize = (2*math.ceil(info.nominal_srate()*plot_duration), info.channel_count())
+        self.buffer = np.empty(bufsize, dtype=self.dtypes[info.channel_format()])
+        empty = np.array([])
+        self.curves = [pg.PlotCurveItem(x=empty, y=empty, autoDownsample=True) for _ in range(self.channel_count)]
+        for curve in self.curves:
+            plt.addItem(curve)
 
-# Create the pyqtgraph window
-win = pg.GraphicsWindow()
-win.setWindowTitle('LSL Plot ' + inlet.info().name())
-plt = win.addPlot()
-plt.setLimits(xMin=0.0, xMax=plot_duration, yMin=-1.0 * (inlet.channel_count - 1), yMax=1.0)
-
-t0 = [local_clock()] * inlet.channel_count
-curves = []
-for ch_ix in range(inlet.channel_count):
-    curves += [plt.plot()]
-
-
-def update():
-    global inlet, curves, t0
-    # Read data from the inlet. Use a timeout of 0.0 so we don't block GUI interaction.
-    chunk, timestamps = inlet.pull_chunk(timeout=0.0, max_samples=32)
-    if timestamps:
-        timestamps = np.asarray(timestamps)
-        y = np.asarray(chunk)
-
-        for ch_ix in range(inlet.channel_count):
-            old_x, old_y = curves[ch_ix].getData()
-            if old_x is not None:
-                old_x += t0[ch_ix]  # Undo t0 subtraction
-                this_x = np.hstack((old_x, timestamps))
-                this_y = np.hstack((old_y, y[:, ch_ix] - ch_ix))
-            else:
-                this_x = timestamps
-                this_y = y[:, ch_ix] - ch_ix
-            t0[ch_ix] = this_x[-1] - plot_duration
-            this_x -= t0[ch_ix]
-            b_keep = this_x >= 0
-            curves[ch_ix].setData(this_x[b_keep], this_y[b_keep])
-    strings, timestamps = markers.pull_chunk(0)
-    if timestamps:
-        print(strings, timestamps)
-        for string, ts in zip(strings, timestamps):
-            plt.addItem(pg.InfiniteLine(ts-t0[0], angle=90, movable=False, label=string[0]))
+    def pull_and_plot(self, plot_time, plt):
+        _, ts = self.inlet.pull_chunk(timeout=0.0,
+                                      max_samples=self.buffer.shape[0],
+                                      dest_obj=self.buffer)
+        if ts:
+            ts = np.asarray(ts)
+            y = self.buffer[0:ts.size, :]
+            this_x = None
+            old_offset = 0
+            new_offset = 0
+            for ch_ix in range(self.channel_count):
+                old_x, old_y = self.curves[ch_ix].getData()
+                if ch_ix == 0:
+                    old_offset = old_x.searchsorted(plot_time)
+                    new_offset = ts.searchsorted(plot_time)
+                    this_x = np.hstack((old_x[old_offset:], ts[new_offset:]))
+                this_y = np.hstack((old_y[old_offset:], y[new_offset:, ch_ix] - ch_ix))
+                self.curves[ch_ix].setData(this_x, this_y)
 
 
+class MarkerInlet(Inlet):
+    def __init__(self, info: pylsl.StreamInfo):
+        super().__init__(info)
 
-timer = QtCore.QTimer()
-timer.timeout.connect(update)
-timer.start(50)
+    def pull_and_plot(self, plot_time, plt):
+        # TODO: purge old markers
+        strings, timestamps = self.inlet.pull_chunk(0)
+        if timestamps:
+            for string, ts in zip(strings, timestamps):
+                plt.addItem(pg.InfiniteLine(ts, angle=90, movable=False, label=string[0]))
 
 
-# Start Qt event loop unless running in interactive mode or using pyside.
-if __name__ == '__main__':
+def main():
+    # first resolve an EEG stream on the lab network
+    inlets: List[Inlet] = []
+    print("looking for streams")
+    streams = pylsl.resolve_streams()
+
+    # Create the pyqtgraph window
+    pw = pg.plot(title='LSL Plot')
+    plt = pw.getPlotItem()
+    plt.enableAutoRange(x=False, y=True)
+
+    for info in streams:
+        if info.type() == 'Markers':
+            if info.nominal_srate() != pylsl.IRREGULAR_RATE \
+                    or info.channel_format() != pylsl.cf_string:
+                print('Invalid marker stream ' + info.name())
+            print('Adding marker inlet: ' + info.name())
+            inlets.append(MarkerInlet(info))
+        elif info.nominal_srate() != pylsl.IRREGULAR_RATE \
+                and info.channel_format() != pylsl.cf_string:
+            print('Adding data inlet: ' + info.name())
+            inlets.append(DataInlet(info, plt))
+        else:
+            print('Don\'t know what to do with stream ' + info.name())
+
+    def scroll():
+        fudge_factor = pull_interval * .002
+        plot_time = pylsl.local_clock()
+        pw.setXRange(plot_time - plot_duration + fudge_factor, plot_time - fudge_factor)
+
+    def update():
+        # Read data from the inlet. Use a timeout of 0.0 so we don't block GUI interaction.
+        current_inlet = 0
+        mintime = pylsl.local_clock()
+        for inlet in inlets:
+            inlet.pull_and_plot(mintime - plot_duration, plt)
+
+    update_timer = QtCore.QTimer()
+    update_timer.timeout.connect(scroll)
+    update_timer.start(update_interval)
+
+    pull_timer = QtCore.QTimer()
+    pull_timer.timeout.connect(update)
+    pull_timer.start(pull_interval)
+
     import sys
+
+    # Start Qt event loop unless running in interactive mode or using pyside.
     if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
         QtGui.QApplication.instance().exec_()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Improve ReceiveAndPlot somewhat:

- use a preallocated buffer for pull_chunk (so even an ancient laptop can show 2 channels @100KHz)
- decouple scrolling and pulling for a smoother experience
- allow multiple data and marker streams
- display all suitable (i.e. data or marker streams) streams found at start time instead of one data and one marker stream