### PR TITLE
perf(inlet): avoid redundant list rebuild in pull_sample

### DIFF
--- a/src/pylsl/inlet.py
+++ b/src/pylsl/inlet.py
@@ -199,9 +199,10 @@ class StreamInlet:
         )
         handle_error(errcode)
         if timestamp:
-            sample = [v for v in self.sample]
             if self.channel_format == cf_string:
-                sample = [v.decode("utf-8") for v in sample]
+                sample = [v.decode("utf-8") for v in self.sample]
+            else:
+                sample = list(self.sample)
             if assign_to is not None:
                 assign_to[:] = sample
             return sample, timestamp


### PR DESCRIPTION
(PR and content generated with the help of Claude)

## What

Avoid a redundant list rebuild in `StreamInlet.pull_sample` without changing its output.

## Why

The old code always built an intermediate list with a comprehension, then for string streams re-iterated it a second time to decode:

```python
sample = [v for v in self.sample]
if self.channel_format == cf_string:
    sample = [v.decode("utf-8") for v in sample]
```

Now the numeric path uses `list(self.sample)` (faster than a comprehension), and the string path decodes directly from the ctypes sample in a single pass with one fewer allocation:

```python
if self.channel_format == cf_string:
    sample = [v.decode("utf-8") for v in self.sample]
else:
    sample = list(self.sample)
```

## Impact

Measured on the extraction step alone (output verified identical via `assert old() == new()`):

| channels | numeric old/new | string old/new |
|---|---|---|
| 8 | 0.69 / 0.62 us (1.12x) | 1.33 / 1.17 us (1.14x) |
| 32 | 2.02 / 1.77 us (1.14x) | 4.23 / 3.89 us (1.09x) |
| 64 | 3.88 / 3.39 us (1.15x) | 8.23 / 7.51 us (1.10x) |

A modest ~1.1-1.2x per call; negligible at 1 channel. `pull_sample` is the most-called function in per-sample loops, so it adds up there, and the string path also drops one throwaway allocation per call.

## Behavior

Identical output: same `list` of values, same string decoding, unchanged legacy `assign_to` and `(None, None)` paths. Verified with a live localhost round-trip (numeric, string, legacy assign_to); existing test suite passes.
