### PR TITLE
refactor(lib): remove duplicated library-search blocks

### DIFF
--- a/src/pylsl/lib/__init__.py
+++ b/src/pylsl/lib/__init__.py
@@ -136,30 +136,6 @@ def find_liblsl_libraries(verbose=False):
             if os.path.isfile(path):
                 yield path
 
-    # The active Python env's lib directory (e.g. `conda install -c conda-forge
-    # liblsl` lands here). ctypes.util.find_library doesn't search here.
-    env_libdir = os.path.join(sys.prefix, "lib")
-    for libprefix in ["", "lib"]:
-        for debugsuffix in ["", "-debug"]:
-            path = os.path.join(env_libdir, libprefix + "lsl" + debugsuffix + libsuffix)
-            if os.path.isfile(path):
-                yield path
-
-    # macOS Frameworks (e.g. installed via `brew install labstreaminglayer/tap/lsl`)
-    # aren't found by ctypes.util.find_library, but the framework binary is a
-    # regular dylib that ctypes.CDLL can load directly.
-    if os_name == "Darwin":
-        framework_roots = [
-            "/opt/homebrew/Frameworks",  # Apple Silicon homebrew
-            "/usr/local/Frameworks",  # Intel homebrew
-            os.path.expanduser("~/Library/Frameworks"),
-            "/Library/Frameworks",
-        ]
-        for root in framework_roots:
-            path = os.path.join(root, "lsl.framework", "lsl")
-            if os.path.isfile(path):
-                yield path
-
 
 __dload_msg = (
     "You can install the LSL library with conda: `conda install -c conda-forge liblsl`"


### PR DESCRIPTION
(PR and content generated with the help of Claude)

## What

Remove duplicated code in `find_liblsl_libraries` (`src/pylsl/lib/__init__.py`).

## Why

The "active Python env lib dir" block **and** the "macOS Frameworks" block were each present **twice, verbatim**. Because the generator is consumed with `next()` (the loader takes the first yielded path), the second copy could only ever re-yield a path already produced by the first — it was effectively dead code.

## Impact

- Removes 24 lines of duplicate code.
- Eliminates up to 8 redundant `os.path.isfile()` calls in the fallback path (when the library hasn't been found by an earlier search location). This only runs at import time, so the runtime impact is negligible — this is primarily a correctness/clarity cleanup.

## Behavior

Unchanged: the set and order of yielded candidate paths is identical (the duplicate added no new paths). `import pylsl` and `find_liblsl_libraries()` verified working after the change; existing test suite passes.
