### PR TITLE
perf(info): avoid duplicate desc().child() lookup in _get_channel_info

### DIFF
--- a/src/pylsl/info.py
+++ b/src/pylsl/info.py
@@ -319,10 +319,10 @@ class StreamInfo:
 
     def _get_channel_info(self, name) -> typing.Optional[list[typing.Optional[str]]]:
         """Get the 'channel/name' element in the XML tree."""
-        if self.desc().child("channels").empty():
+        channels = self.desc().child("channels")
+        if channels.empty():
             return None
         ch_infos = list()
-        channels = self.desc().child("channels")
         ch = channels.child("channel")
         while not ch.empty():
             ch_info = ch.child(name).first_child().value()


### PR DESCRIPTION
(PR and content generated with the help of Claude)

## What

Compute `self.desc().child("channels")` once in `StreamInfo._get_channel_info` instead of twice.

## Why

The method fetched the same node twice — once for the `.empty()` guard and again to start iterating:

```python
if self.desc().child("channels").empty():
    return None
ch_infos = list()
channels = self.desc().child("channels")
```

Each `self.desc().child("channels")` is two liblsl FFI calls (`lsl_get_desc` + `lsl_child`) plus an `XMLElement` allocation. Now it's computed once and reused:

```python
channels = self.desc().child("channels")
if channels.empty():
    return None
ch_infos = list()
```

## Impact

Eliminates 2 redundant FFI calls + 1 object allocation per call to `get_channel_labels`/`get_channel_types`/`get_channel_units`. This is a cold path (metadata read, not streaming), so the runtime impact is small — it's mainly a clarity/cleanliness fix.

## Behavior

Unchanged. Verified the empty->`None` branch and label/type/unit round-trips; existing test suite passes.
